### PR TITLE
Generalize the nuclei segmentation code

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ numpy>=1.14.1
 matplotlib>=2.1.2
 scipy>=1.0
 Pillow>=5.0.0
+scikit-image>=0.13.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+click>=6.6
+numpy>=1.14.1
+matplotlib>=2.1.2
+scipy>=1.0
+Pillow>=5.0.0


### PR DESCRIPTION
A generalization of the nuclei segmentation code.

The following changes are included:
- Split the segmentation process into separate functions
- Add functionality for commandline I/O [Changed from hardcoded image paths]
- Add optional logging
- Add commandline option for plotting [changed from always plotting]
- Add requirements.txt

The algorithm itself remains unchanged.